### PR TITLE
Improve image_process

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,5 +3,7 @@ python:
   - "2.7"
   - "3.3"
   - "3.4"
-install: "pip install pelican pillow beautifulsoup4 mock"
-script: "python test_image_process.py"
+install: "pip install pelican pillow beautifulsoup4 mock pep8"
+script:
+  - "pep8 ."
+  - "python test_image_process.py"

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,5 +5,5 @@ python:
   - "3.2"
   - "3.3"
   - "3.4"
-install: "pip install PIL beautifulsoup4 mock"
+install: "pip install pelican pillow beautifulsoup4 mock"
 script: "python test_image_process.py"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
 language: python
 python:
-  - "2.6"
   - "2.7"
-  - "3.2"
   - "3.3"
   - "3.4"
 install: "pip install pelican pillow beautifulsoup4 mock"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,9 @@
+language: python
+python:
+  - "2.6"
+  - "2.7"
+  - "3.2"
+  - "3.3"
+  - "3.4"
+install: "pip install PIL beautifulsoup4 mock"
+script: "python test_image_process.py"

--- a/Readme.rst
+++ b/Readme.rst
@@ -408,8 +408,15 @@ Destination directory
 ~~~~~~~~~~~~~~~~~~~~~
 
 By default, the new images will be stored in a directory named
-``derivative/<TRANSFORMATION_NAME>`` in the directory of the original
-image. You can replace ``derivative`` by something else using the
+``derivative/<TRANSFORMATION_NAME>`` in the output folder at
+the same location as the original image.
+For example if the original image is located in
+the ``content/images`` folder. The computed images will be stored
+in the ``output/images/derivative/<TRANSFORMATION_NAME>``.
+All the transformations are done in the output directory in order
+to avoid confusion with the source files or if we test multiple
+transformations.
+You can replace ``derivative`` by something else using the
 ``IMAGE_PROCESS_DIR`` setting in your Pelican configuration file:
 
 .. code-block:: python

--- a/image_process.py
+++ b/image_process.py
@@ -177,7 +177,7 @@ def harvest_images(path, context):
         res = harvest_images_in_fragment(f, context)
         f.seek(0)
         f.truncate()
-        f.write(res)
+        f.write(res.encode('utf8'))
 
 
 def harvest_images_in_fragment(fragment, settings):
@@ -228,7 +228,7 @@ def harvest_images_in_fragment(fragment, settings):
             elif group.name == 'picture':
                 process_picture(soup, img, group, settings, derivative)
 
-    return str(soup)
+    return unicode(soup)
 
 
 def compute_paths(img, settings, derivative):
@@ -265,7 +265,7 @@ def build_srcset(img, settings, derivative):
     elif isinstance(default, list):
         default_name = 'default'
         destination = os.path.join(path.base_path, default_name, path.filename)
-        process_image((path.source, path.destination, default), settings)
+        process_image((path.source, destination, default), settings)
 
     img['src'] = os.path.join(path.base_url, default_name, path.filename)
 
@@ -293,7 +293,7 @@ def convert_div_to_picture_tag(soup, img, group, settings, derivative):
     # image URL. Other sources use the img with classes
     # [source['name'], 'image-process'].  We also remove the img from
     # the DOM.
-    sources = copy.deepcopy(path.process_dir[derivative]['sources'])
+    sources = copy.deepcopy(settings['IMAGE_PROCESS'][derivative]['sources'])
     for s in sources:
         if s['name'] == 'default':
             s['url'] = img['src']
@@ -479,9 +479,9 @@ def process_image(image, settings):
     # If original image is older than existing derivative, skip
     # processing to save time, unless user explicitely forced
     # image generation.
-    if (settings['IMAGE_PROCESS_FORCE']) or \
-            (not os.path.exists(image[1])) or \
-            (os.path.getmtime(image[0]) > os.path.getmtime(image[1])):
+    if (settings['IMAGE_PROCESS_FORCE'] or
+        not os.path.exists(image[1]) or
+        os.path.getmtime(image[0]) > os.path.getmtime(image[1])):
 
         i = Image.open(image[0])
 

--- a/image_process.py
+++ b/image_process.py
@@ -307,10 +307,7 @@ def convert_div_to_picture_tag(soup, img, group, settings, derivative):
 
         url_path, s['filename'] = os.path.split(s['url'])
         s['base_url'] = os.path.join(url_path, process_dir, derivative)
-
-        source = os.path.join(settings['PATH'], s['url'][1:])
-        output_path, _ = os.path.split(source)
-        s['base_path'] = os.path.join(output_path, process_dir, derivative)
+        s['base_path'] = os.path.join(settings['OUTPUT_PATH'], s['base_url'][1:])
 
     # If default is not None, change default img source to the image
     # derivative referenced.
@@ -407,10 +404,9 @@ def process_picture(soup, img, group, settings, derivative):
 
         url_path, s['filename'] = os.path.split(s['url'])
         s['base_url'] = os.path.join(url_path, process_dir, derivative)
+        s['base_path'] = os.path.join(settings['OUTPUT_PATH'], s['base_url'][1:])
 
-        source = os.path.join(settings['PATH'], s['url'][1:])
-        output_path, _ = os.path.split(source)
-        s['base_path'] = os.path.join(output_path, process_dir, derivative)
+
 
     # If default is not None, change default img source to the image
     # derivative referenced.

--- a/image_process.py
+++ b/image_process.py
@@ -173,12 +173,11 @@ def harvest_images(path, context):
     if 'IMAGE_PROCESS_DIR' not in context:
         context['IMAGE_PROCESS_DIR'] = 'derivatives'
 
-    with open(path, 'r') as f:
+    with open(path, 'r+') as f:
         res = harvest_images_in_fragment(f, context)
-
-    with open(path, 'w') as f:
+        f.seek(0)
+        f.truncate()
         f.write(res)
-
 
 
 def harvest_images_in_fragment(fragment, settings):

--- a/image_process.py
+++ b/image_process.py
@@ -233,16 +233,12 @@ def harvest_images_in_fragment(fragment, settings):
 
 
 def compute_paths(img, settings, derivative):
-
     process_dir = settings['IMAGE_PROCESS_DIR']
-
     url_path, filename = os.path.split(img['src'])
-
     base_url = os.path.join(url_path, process_dir, derivative)
 
     source = os.path.join(settings['PATH'], img['src'][1:])
-    output_path, _ = os.path.split(source)
-    base_path = os.path.join(output_path, process_dir, derivative)
+    base_path = os.path.join(settings['OUTPUT_PATH'], base_url[1:])
 
     return Path(base_url, source, base_path, filename, process_dir)
 

--- a/image_process.py
+++ b/image_process.py
@@ -180,7 +180,7 @@ def harvest_images(path, context):
         res = harvest_images_in_fragment(f, context)
         f.seek(0)
         f.truncate()
-        f.write(res.encode('utf8'))
+        f.write(res)
 
 
 def harvest_images_in_fragment(fragment, settings):

--- a/image_process.py
+++ b/image_process.py
@@ -228,7 +228,7 @@ def harvest_images_in_fragment(fragment, settings):
             elif group.name == 'picture':
                 process_picture(soup, img, group, settings, derivative)
 
-    return unicode(soup)
+    return str(soup)
 
 
 def compute_paths(img, settings, derivative):

--- a/image_process.py
+++ b/image_process.py
@@ -24,6 +24,7 @@ Path = collections.namedtuple(
     'Path', ['base_url', 'source', 'base_path', 'filename', 'process_dir']
 )
 
+
 def convert_box(image, t, l, r, b):
     """Convert box coordinates strings to integer.
 
@@ -51,7 +52,7 @@ def convert_box(image, t, l, r, b):
     else:
         b = float(b)
 
-    return (t,l,r,b)
+    return (t, l, r, b)
 
 
 def crop(i, t, l, r, b):
@@ -60,8 +61,8 @@ def crop(i, t, l, r, b):
     t, l, r, b (top, left, right, bottom) must be strings specifying
     either a number or a percentage.
     """
-    t,l,r,b = convert_box(i, t, l, r, b)
-    return i.crop((int(t),int(l),int(r),int(b)))
+    t, l, r, b = convert_box(i, t, l, r, b)
+    return i.crop((int(t), int(l), int(r), int(b)))
 
 
 def resize(i, w, h):
@@ -77,7 +78,7 @@ def resize(i, w, h):
     elif i.mode == '1':
         i = i.convert('L')
 
-    return i.resize((int(w),int(h)), Image.LANCZOS)
+    return i.resize((int(w), int(h)), Image.LANCZOS)
 
 
 def scale(i, w, h, upscale, inside):
@@ -158,8 +159,10 @@ basic_ops = {
     'blur': functools.partial(apply_filter, f=ImageFilter.BLUR),
     'contour': functools.partial(apply_filter, f=ImageFilter.CONTOUR),
     'detail': functools.partial(apply_filter, f=ImageFilter.DETAIL),
-    'edge_enhance': functools.partial(apply_filter, f=ImageFilter.EDGE_ENHANCE),
-    'edge_enhance_more': functools.partial(apply_filter, f=ImageFilter.EDGE_ENHANCE_MORE),
+    'edge_enhance': functools.partial(apply_filter,
+                                      f=ImageFilter.EDGE_ENHANCE),
+    'edge_enhance_more': functools.partial(apply_filter,
+                                           f=ImageFilter.EDGE_ENHANCE_MORE),
     'emboss': functools.partial(apply_filter, f=ImageFilter.EMBOSS),
     'find_edges': functools.partial(apply_filter, f=ImageFilter.FIND_EDGES),
     'smooth': functools.partial(apply_filter, f=ImageFilter.SMOOTH),
@@ -201,30 +204,27 @@ def harvest_images_in_fragment(fragment, settings):
             # Single source image specification.
             process_img_tag(img, settings, derivative)
 
-
         elif not isinstance(d, dict):
             raise RuntimeError('Derivative %s definition not handled'
-                '(must be list or dict)' % (derivative))
+                               '(must be list or dict)' % (derivative))
 
         elif 'type' not in d:
             raise RuntimeError('"type" is mandatory for %s.' % derivative)
-
 
         elif d['type'] == 'image':
             # Single source image specification.
             process_img_tag(img, settings, derivative)
 
-
         elif d['type'] == 'responsive-image':
             # srcset image specification.
             build_srcset(img, settings, derivative)
-
 
         elif d['type'] == 'picture':
             # Multiple source (picture) specification.
             group = img.find_parent()
             if group.name == 'div':
-                convert_div_to_picture_tag(soup, img, group, settings, derivative)
+                convert_div_to_picture_tag(soup, img, group, settings,
+                                           derivative)
             elif group.name == 'picture':
                 process_picture(soup, img, group, settings, derivative)
 
@@ -274,9 +274,8 @@ def build_srcset(img, settings, derivative):
 
     srcset = []
     for src in process['srcset']:
-        srcset.append("%s %s" %
-            (os.path.join(path.base_url, src[0], path.filename), src[0])
-        )
+        file_path = os.path.join(path.base_url, src[0], path.filename)
+        srcset.append("%s %s" % (file_path, src[0]))
         destination = os.path.join(path.base_path, src[0], path.filename)
         process_image((path.source, destination, src[1]), settings)
 
@@ -307,7 +306,8 @@ def convert_div_to_picture_tag(soup, img, group, settings, derivative):
 
         url_path, s['filename'] = os.path.split(s['url'])
         s['base_url'] = os.path.join(url_path, process_dir, derivative)
-        s['base_path'] = os.path.join(settings['OUTPUT_PATH'], s['base_url'][1:])
+        s['base_path'] = os.path.join(settings['OUTPUT_PATH'],
+                                      s['base_url'][1:])
 
     # If default is not None, change default img source to the image
     # derivative referenced.
@@ -322,8 +322,10 @@ def convert_div_to_picture_tag(soup, img, group, settings, derivative):
                 break
 
         if default_source is None:
-            raise RuntimeError('No source matching "%s", referenced in default setting.',
-                               (default_source_name,))
+            raise RuntimeError(
+                'No source matching "%s", referenced in default setting.',
+                (default_source_name,)
+            )
 
         if isinstance(default[1], six.string_types):
             default_item_name = default[1]
@@ -333,27 +335,30 @@ def convert_div_to_picture_tag(soup, img, group, settings, derivative):
 
             source = os.path.join(settings['PATH'], default_source['url'][1:])
             destination = os.path.join(s['base_path'], default_source_name,
-                                       default_item_name, default_source['filename'])
+                                       default_item_name,
+                                       default_source['filename'])
             process_image((source, destination, default[1]), settings)
 
         # Change img src to url of default processed image.
-        img['src'] = os.path.join(s['base_url'], default_source_name, default_item_name,
+        img['src'] = os.path.join(s['base_url'], default_source_name,
+                                  default_item_name,
                                   default_source['filename'])
 
     # Create picture tag.
     picture_tag = soup.new_tag('picture')
     for s in sources:
         # Create new <source>
-        source_attrs = {k:s[k] for k in s if k in ['media', 'sizes']}
+        source_attrs = {k: s[k] for k in s if k in ['media', 'sizes']}
         source_tag = soup.new_tag('source', **source_attrs)
 
         srcset = []
         for src in s['srcset']:
-            srcset.append("%s %s" % (os.path.join(s['base_url'], s['name'], src[0], s['filename']),
-                                     src[0]))
+            srcset.append("%s %s" % (os.path.join(s['base_url'], s['name'],
+                                     src[0], s['filename']), src[0]))
 
             source = os.path.join(settings['PATH'], s['url'][1:])
-            destination = os.path.join(s['base_path'], s['name'], src[0], s['filename'])
+            destination = os.path.join(s['base_path'], s['name'], src[0],
+                                       s['filename'])
             process_image((source, destination, src[1]), settings)
 
         if len(srcset) > 0:
@@ -385,6 +390,7 @@ def process_picture(soup, img, group, settings, derivative):
     </picture>
 
     """
+
     process_dir = settings['IMAGE_PROCESS_DIR']
     process = settings['IMAGE_PROCESS'][derivative]
     # Compile sources URL. Special source "default" uses the main
@@ -394,7 +400,7 @@ def process_picture(soup, img, group, settings, derivative):
     for s in sources:
         if s['name'] == 'default':
             s['url'] = img['src']
-            source_attrs = {k:s[k] for k in s if k in ['media', 'sizes']}
+            source_attrs = {k: s[k] for k in s if k in ['media', 'sizes']}
             s['element'] = soup.new_tag('source', **source_attrs)
         else:
             s['element'] = group.find('source', class_=s['name']).extract()
@@ -404,9 +410,8 @@ def process_picture(soup, img, group, settings, derivative):
 
         url_path, s['filename'] = os.path.split(s['url'])
         s['base_url'] = os.path.join(url_path, process_dir, derivative)
-        s['base_path'] = os.path.join(settings['OUTPUT_PATH'], s['base_url'][1:])
-
-
+        s['base_path'] = os.path.join(settings['OUTPUT_PATH'],
+                                      s['base_url'][1:])
 
     # If default is not None, change default img source to the image
     # derivative referenced.
@@ -421,34 +426,38 @@ def process_picture(soup, img, group, settings, derivative):
                 break
 
         if default_source is None:
-            raise RuntimeError('No source matching "%s", referenced in default setting.',
-                               (default_source_name,))
+            raise RuntimeError(
+                'No source matching "%s", referenced in default setting.',
+                (default_source_name,)
+            )
 
         if isinstance(default[1], six.string_types):
             default_item_name = default[1]
 
         elif isinstance(default[1], list):
             default_item_name = 'default'
-
             source = os.path.join(settings['PATH'], default_source['url'][1:])
             destination = os.path.join(s['base_path'], default_source_name,
-                                       default_item_name, default_source['filename'])
+                                       default_item_name,
+                                       default_source['filename'])
+
             process_image((source, destination, default[1]), settings)
 
-
         # Change img src to url of default processed image.
-        img['src'] = os.path.join(s['base_url'], default_source_name, default_item_name,
+        img['src'] = os.path.join(s['base_url'], default_source_name,
+                                  default_item_name,
                                   default_source['filename'])
 
     # Generate srcsets and put back <source>s in <picture>.
     for s in sources:
         srcset = []
         for src in s['srcset']:
-            srcset.append("%s %s" % (os.path.join(s['base_url'], s['name'], src[0], s['filename']),
-                                     src[0]))
+            srcset.append("%s %s" % (os.path.join(s['base_url'], s['name'],
+                                     src[0], s['filename']), src[0]))
 
             source = os.path.join(settings['PATH'], s['url'][1:])
-            destination = os.path.join(s['base_path'], s['name'], src[0], s['filename'])
+            destination = os.path.join(s['base_path'], s['name'], src[0],
+                                       s['filename'])
             process_image((source, destination, src[1]), settings)
 
         if len(srcset) > 0:
@@ -477,7 +486,7 @@ def process_image(image, settings):
     # image generation.
     if (settings['IMAGE_PROCESS_FORCE'] or
         not os.path.exists(image[1]) or
-        os.path.getmtime(image[0]) > os.path.getmtime(image[1])):
+            os.path.getmtime(image[0]) > os.path.getmtime(image[1])):
 
         i = Image.open(image[0])
 
@@ -489,6 +498,7 @@ def process_image(image, settings):
                 i = basic_ops[elems[0]](i, *(elems[1:]))
 
         i.save(image[1])
+
 
 def register():
     signals.content_written.connect(harvest_images)

--- a/image_process.py
+++ b/image_process.py
@@ -184,7 +184,6 @@ def harvest_images(path, context):
 
 
 def harvest_images_in_fragment(fragment, settings):
-    fragment_changed = False
     soup = BeautifulSoup(fragment, 'html.parser')
 
     for img in soup.find_all('img', class_=IMAGE_PROCESS_REGEX):

--- a/test_image_process.py
+++ b/test_image_process.py
@@ -9,7 +9,7 @@ from pelican.tests.support import unittest, get_settings, temporary_folder
 from image_process import harvest_images_in_fragment, process_image
 
 try:
-    import unittest.mock as mock # python < 3.3
+    import unittest.mock as mock  # python < 3.3
 except ImportError:
     import mock
 
@@ -31,7 +31,7 @@ class ImageDerivativeTest(unittest.TestCase):
         'scale_out': ['scale_out 200 250 False'],
         'blur': ['blur'],
         'contour': ['contour'],
-        'detail':['detail'],
+        'detail': ['detail'],
         'edge_enhance': ['edge_enhance'],
         'edge_enhance_more': ['edge_enhance_more'],
         'emboss': ['emboss'],
@@ -52,20 +52,20 @@ class ImageDerivativeTest(unittest.TestCase):
 
         html = harvest_images_in_fragment(html, settings)
 
-        expected_content = ('<img class="test image-process image-process-crop test2"'
-                            ' src="/tmp/derivatives/crop/test.jpg"/>')
+        expected_content = ('<img class="test image-process image-process-crop'
+                            ' test2" src="/tmp/derivatives/crop/test.jpg"/>')
 
         expected_source = os.path.join(settings['PATH'], 'tmp/test.jpg')
         expected_destination = os.path.join(
             settings['OUTPUT_PATH'], 'tmp', settings['IMAGE_PROCESS_DIR'],
             'crop', 'test.jpg'
         )
-        expected_image = (expected_source, expected_destination, ['crop 10 20 100 200'])
+        expected_image = (expected_source, expected_destination,
+                          ['crop 10 20 100 200'])
         expected_calls = [mock.call(expected_image, settings)]
 
         self.assertEqual(html, expected_content)
         self.assertEqual(expected_calls, process_image.call_args_list)
-
 
     def test_transforms(self):
         settings = get_settings(IMAGE_PROCESS=self.transforms)
@@ -87,7 +87,7 @@ class ImageDerivativeTest(unittest.TestCase):
 
         with temporary_folder() as tmpdir:
             [test_transform(d, i, tmpdir)
-                    for d in self.transforms for i in TEST_IMAGES]
+             for d in self.transforms for i in TEST_IMAGES]
 
 
 class HTMLGenerationTest(unittest.TestCase):
@@ -101,10 +101,10 @@ class HTMLGenerationTest(unittest.TestCase):
         },
         'crisp': {
             'type': 'responsive-image',
-             'srcset': [('1x', ["scale_in 800 600 True"]),
-                        ('2x', ["scale_in 1600 1200 True"]),
-                        ('4x', ["scale_in 3200 2400 True"])],
-              'default': '1x',
+            'srcset': [('1x', ["scale_in 800 600 True"]),
+                       ('2x', ["scale_in 1600 1200 True"]),
+                       ('4x', ["scale_in 3200 2400 True"])],
+            'default': '1x',
         },
         'crisp2': {
             'type': 'responsive-image',
@@ -155,8 +155,7 @@ class HTMLGenerationTest(unittest.TestCase):
                 }, {
                     'name': 'source-2',
                     'srcset': [('1x', ["crop 100 100 200 200"]),
-                               ('2x', ["crop 100 100 300 300"]),
-                                          ]
+                               ('2x', ["crop 100 100 300 300"])]
                 }
             ],
             'default': ('source-2', ["scale_in 800 600 True"]),
@@ -168,7 +167,6 @@ class HTMLGenerationTest(unittest.TestCase):
         html = '<img class="image-process-undefined" src="/tmp/test.jpg" />'
         with self.assertRaises(RuntimeError):
             harvest_images_in_fragment(html, settings)
-
 
     @mock.patch('image_process.process_image')
     def test_image_generation(self, process_image):
@@ -182,13 +180,11 @@ class HTMLGenerationTest(unittest.TestCase):
              (
                  'tmp/test.jpg', 'thumb/test.jpg',
                  ["crop 0 0 50% 50%", "scale_out 150 150", "crop 0 0 150 150"]
-             )
-            ),
+             )),
             ('<img class="image-process-article-image" src="/tmp/test.jpg" />',
              '<img class="image-process-article-image" '
              'src="/tmp/derivs/article-image/test.jpg"/>',
-             ('tmp/test.jpg', 'article-image/test.jpg', ["scale_in 300 300"])
-            )
+             ('tmp/test.jpg', 'article-image/test.jpg', ["scale_in 300 300"]))
         ]
 
         for data in test_data:
@@ -207,7 +203,6 @@ class HTMLGenerationTest(unittest.TestCase):
             self.assertEqual(expected_calls, process_image.call_args_list)
             process_image.reset_mock()
 
-
     @mock.patch('image_process.process_image')
     def test_responsive_image_generation(self, process_image):
         settings = get_settings(IMAGE_PROCESS=self.valid_transforms,
@@ -221,11 +216,11 @@ class HTMLGenerationTest(unittest.TestCase):
              '/tmp/derivs/crisp/4x/test.jpg 4x"/>',
 
              [('tmp/test.jpg', 'crisp/1x/test.jpg',
-                  ["scale_in 800 600 True"]),
+               ["scale_in 800 600 True"]),
               ('tmp/test.jpg', 'crisp/2x/test.jpg',
-                  ["scale_in 1600 1200 True"]),
+               ["scale_in 1600 1200 True"]),
               ('tmp/test.jpg', 'crisp/4x/test.jpg',
-                  ["scale_in 3200 2400 True"]),
+               ["scale_in 3200 2400 True"]),
               ]),
 
             ('<img class="image-process-crisp2" src="/tmp/test.jpg" />',
@@ -237,28 +232,27 @@ class HTMLGenerationTest(unittest.TestCase):
 
              # default must be first, because the process execute it first
              [('tmp/test.jpg', 'crisp2/default/test.jpg',
-                  ["scale_in 400 300 True"]),
+               ["scale_in 400 300 True"]),
               ('tmp/test.jpg', 'crisp2/1x/test.jpg',
-                  ["scale_in 800 600 True"]),
+               ["scale_in 800 600 True"]),
               ('tmp/test.jpg', 'crisp2/2x/test.jpg',
-                  ["scale_in 1600 1200 True"]),
+               ["scale_in 1600 1200 True"]),
               ('tmp/test.jpg', 'crisp2/4x/test.jpg',
-                  ["scale_in 3200 2400 True"])
-             ]),
+               ["scale_in 3200 2400 True"])]),
 
             ('<img class="image-process-large-photo" src="/tmp/test.jpg" />',
-             '<img class="image-process-large-photo" sizes="(min-width: 1200px) '
-             '800px, (min-width: 992px) 650px, (min-width: 768px) 718px, '
-             '100vw" src="/tmp/derivs/large-photo/800w/test.jpg" '
-             'srcset="/tmp/derivs/large-photo/600w/test.jpg 600w, '
-             '/tmp/derivs/large-photo/800w/test.jpg 800w, '
+             '<img class="image-process-large-photo" '
+             'sizes="(min-width: 1200px) 800px, (min-width: 992px) 650px, '
+             '(min-width: 768px) 718px, 100vw" src="/tmp/derivs/large-photo/'
+             '800w/test.jpg" srcset="/tmp/derivs/large-photo/600w/test.jpg '
+             '600w, /tmp/derivs/large-photo/800w/test.jpg 800w, '
              '/tmp/derivs/large-photo/1600w/test.jpg 1600w"/>',
              [('tmp/test.jpg', 'large-photo/600w/test.jpg',
-                  ["scale_in 600 450 True"]),
+               ["scale_in 600 450 True"]),
               ('tmp/test.jpg', 'large-photo/800w/test.jpg',
-                  ["scale_in 800 600 True"]),
+               ["scale_in 800 600 True"]),
               ('tmp/test.jpg', 'large-photo/1600w/test.jpg',
-                  ["scale_in 1600 1200 True"]),
+               ["scale_in 1600 1200 True"]),
               ]),
         ]
 
@@ -279,13 +273,11 @@ class HTMLGenerationTest(unittest.TestCase):
                 expected_images.append(expected_image)
                 expected_calls.append(mock.call(expected_image, settings))
 
-
             self.maxDiff = None
             self.assertEqual(html, data[1])
             self.assertEqual(process_image.call_args_list, expected_calls)
 
             process_image.reset_mock()
-
 
     @mock.patch('image_process.process_image')
     def test_picture_generation(self, process_image):
@@ -321,21 +313,21 @@ class HTMLGenerationTest(unittest.TestCase):
               ]),
 
             ('<div class="figure"><img alt="Pelican" class="image-process'
-            '-pict2" src="/images/pelican.jpg" /> <p class="caption">'
-            'A nice pelican</p> <div class="legend"> <img alt="Other view of '
-            'pelican" class="image-process source-2" src="/images/'
-            'pelican-closeup.jpg" /> </div> </div>',
+             '-pict2" src="/images/pelican.jpg" /> <p class="caption">'
+             'A nice pelican</p> <div class="legend"> <img alt="Other view of '
+             'pelican" class="image-process source-2" src="/images/'
+             'pelican-closeup.jpg" /></div></div>',
 
              '<div class="figure"><picture><source media="(min-width: 640px)" '
              'sizes="100vw" srcset="/images/derivs/pict2/default/640w/pelican'
-             '.jpg 640w, /images/derivs/pict2/default/1024w/pelican.jpg 1024w, '
-             '/images/derivs/pict2/default/1600w/pelican.jpg 1600w"></source>'
+             '.jpg 640w, /images/derivs/pict2/default/1024w/pelican.jpg 1024w,'
+             ' /images/derivs/pict2/default/1600w/pelican.jpg 1600w"></source>'
              '<source srcset="/images/derivs/pict2/source-2/1x/pelican-closeup'
              '.jpg 1x, /images/derivs/pict2/source-2/2x/pelican-closeup.jpg '
              '2x"></source><img alt="Pelican" class="image-process-pict2" '
-             'src="/images/derivs/pict2/source-2/default/pelican-closeup.jpg"/>'
-             '</picture> <p class="caption">A nice pelican</p> <div '
-             'class="legend">  </div> </div>',
+             'src="/images/derivs/pict2/source-2/default/pelican-closeup.jpg"'
+             '/></picture> <p class="caption">A nice pelican</p> <div '
+             'class="legend"> </div></div>',
 
              [
                 # default call first

--- a/test_image_process.py
+++ b/test_image_process.py
@@ -60,7 +60,7 @@ class ImageDerivativeTest(unittest.TestCase):
             settings['OUTPUT_PATH'], 'tmp', settings['IMAGE_PROCESS_DIR'],
             'crop', 'test.jpg'
         )
-        expected_image = (expected_source, expected_destination, [u'crop 10 20 100 200'])
+        expected_image = (expected_source, expected_destination, ['crop 10 20 100 200'])
         expected_calls = [mock.call(expected_image, settings)]
 
         self.assertEqual(html, expected_content)

--- a/test_image_process.py
+++ b/test_image_process.py
@@ -337,22 +337,28 @@ class HTMLGenerationTest(unittest.TestCase):
              '</picture> <p class="caption">A nice pelican</p> <div '
              'class="legend">  </div> </div>',
 
-             [('images/pelican.jpg', 'pict2/default/640w/pelican.jpg',
+             [
+                # default call first
+                ('images/pelican-closeup.jpg',
+                 'pict2/source-2/default/pelican-closeup.jpg',
+                 ["scale_in 800 600 True"]),
+
+                ('images/pelican.jpg', 'pict2/default/640w/pelican.jpg',
                  ["scale_in 640 480 True"]),
-              ('images/pelican.jpg', 'pict2/default/1024w/pelican.jpg',
+
+                # then images in order of processing
+                ('images/pelican.jpg', 'pict2/default/1024w/pelican.jpg',
                  ["scale_in 1024 683 True"]),
-              ('images/pelican.jpg', 'pict2/default/1600w/pelican.jpg',
+                ('images/pelican.jpg', 'pict2/default/1600w/pelican.jpg',
                  ["scale_in 1600 1200 True"]),
-              ('images/pelican-closeup.jpg',
+
+                ('images/pelican-closeup.jpg',
                  'pict2/source-2/1x/pelican-closeup.jpg',
                  ["crop 100 100 200 200"]),
-              ('images/pelican-closeup.jpg',
+                ('images/pelican-closeup.jpg',
                  'pict2/source-2/2x/pelican-closeup.jpg',
-                 ["crop 100 100 300 300"]),
-              ('images/pelican-closeup.jpg',
-                 'pict2/source-2/default/pelican-closeup.jpg',
-                 ["scale_in 800 600 True"])
-              ]),
+                 ["crop 100 100 300 300"])
+              ])
            ]
 
         for data in test_data:
@@ -363,7 +369,7 @@ class HTMLGenerationTest(unittest.TestCase):
             for t in data[2]:
                 expected_source = os.path.join(settings['PATH'], t[0])
                 expected_destination = os.path.join(
-                    settings['OUTPUT_PATH'], 'tmp',
+                    settings['OUTPUT_PATH'], 'images',
                     settings['IMAGE_PROCESS_DIR'], t[1]
                 )
 
@@ -373,10 +379,9 @@ class HTMLGenerationTest(unittest.TestCase):
 
             self.maxDiff = None
             self.assertEqual(html, data[1])
-            #for i in images:
-            #    self.assertIn(i, expected_images)
-            #for i in expected_images:
-            #    self.assertIn(i, images)
+            self.assertEqual(process_image.call_args_list, expected_calls)
+
+            process_image.reset_mock()
 
 
 if __name__ == '__main__':

--- a/test_image_process.py
+++ b/test_image_process.py
@@ -2,24 +2,22 @@
 from __future__ import unicode_literals
 
 import os
-
 from PIL import Image, ImageChops
 from pelican.tests.support import unittest, get_settings, temporary_folder
 
-from image_process import images, harvest_images, process_images
+
+from image_process import harvest_images_in_fragment, process_image
+
+try:
+    import unittest.mock as mock # python < 3.3
+except ImportError:
+    import mock
 
 
 CUR_DIR = os.path.dirname(__file__)
-TEST_IMAGES = [os.path.join(CUR_DIR, 'test_data/pelican-bird.jpg'), os.path.join(CUR_DIR, 'test_data/pelican-bird.png')]
+TEST_IMAGES = [os.path.join(CUR_DIR, 'test_data/pelican-bird.jpg'),
+               os.path.join(CUR_DIR, 'test_data/pelican-bird.png')]
 
-class Pelican(object):
-    def __init__(self, settings):
-        self.settings = settings
-
-class Instance(object):
-    def __init__(self, content, settings):
-        self._content = content
-        self.settings = settings
 
 class ImageDerivativeTest(unittest.TestCase):
     transforms = {
@@ -43,46 +41,54 @@ class ImageDerivativeTest(unittest.TestCase):
         'sharpen': ['sharpen'],
         }
 
-    def test_extraction(self):
-        settings = get_settings(IMAGE_PROCESS = self.transforms)
-        html = '<img class="test image-process image-process-crop test2" src="/tmp/test.jpg" />'
-        c = Instance(html, settings)
+    @mock.patch('image_process.process_image')
+    def test_extraction(self, process_image):
 
-        del images[:]
-        harvest_images(c)
+        settings = get_settings(
+            IMAGE_PROCESS_DIR='derivatives', IMAGE_PROCESS=self.transforms
+        )
+        html = ('<img class="test image-process image-process-crop test2"'
+                ' src="/tmp/test.jpg" />')
 
-        expected_content = '<img class="test image-process image-process-crop test2" src="/tmp/derivatives/crop/test.jpg"/>'
+        html = harvest_images_in_fragment(html, settings)
+
+        expected_content = ('<img class="test image-process image-process-crop test2"'
+                            ' src="/tmp/derivatives/crop/test.jpg"/>')
 
         expected_source = os.path.join(settings['PATH'], 'tmp/test.jpg')
-        output_path, _ = os.path.split(expected_source)
-        base_path = os.path.join(output_path, settings['IMAGE_PROCESS_DIR'], 'crop')
-        expected_destination = os.path.join(base_path, 'test.jpg')
-        expected_images = [(expected_source, expected_destination, [u'crop 10 20 100 200'])]
+        expected_destination = os.path.join(
+            settings['OUTPUT_PATH'], 'tmp', settings['IMAGE_PROCESS_DIR'],
+            'crop', 'test.jpg'
+        )
+        expected_image = (expected_source, expected_destination, [u'crop 10 20 100 200'])
+        expected_calls = [mock.call(expected_image, settings)]
 
-        self.assertEqual(c._content, expected_content)
-        self.assertEqual(images, expected_images)
+        self.assertEqual(html, expected_content)
+        self.assertEqual(expected_calls, process_image.call_args_list)
 
 
     def test_transforms(self):
-        settings = get_settings(IMAGE_PROCESS = self.transforms)
-        p = Pelican(settings)
-        del images[:]
+        settings = get_settings(IMAGE_PROCESS=self.transforms)
+
+        def test_transform(d, i, tmpdir):
+            path, name = os.path.split(i)
+            destination = os.path.join(tmpdir, d, name)
+            image = (i, destination, settings['IMAGE_PROCESS'][d])
+
+            process_image(image, settings)
+
+            transformed = Image.open(destination)
+
+            expected_path = os.path.join(path, 'results', d, name)
+            expected = Image.open(expected_path)
+
+            img_diff = ImageChops.difference(transformed, expected).getbbox()
+            self.assertEqual(img_diff, None)
+
         with temporary_folder() as tmpdir:
-            for d in self.transforms:
-                for i in TEST_IMAGES:
-                    _, name = os.path.split(i)
-                    destination = os.path.join(tmpdir, d, name)
-                    images.append((i, destination, settings['IMAGE_PROCESS'][d]))
-            process_images(p)
+            [test_transform(d, i, tmpdir)
+                    for d in self.transforms for i in TEST_IMAGES]
 
-            for i in images:
-                transformed = Image.open(i[1])
-
-                path, name = os.path.split(i[0])
-                expected_path = os.path.join(path, 'results', i[2], name)
-                expected = Image.open(expected_path)
-
-                self.assertEqual(ImageChops.difference(transformed, expected).getbbox(), None)
 
 class HTMLGenerationTest(unittest.TestCase):
     """
@@ -90,197 +96,287 @@ class HTMLGenerationTest(unittest.TestCase):
     """
     valid_transforms = {
         'thumb': ["crop 0 0 50% 50%", "scale_out 150 150", "crop 0 0 150 150"],
-        'article-image': {'type': 'image',
-                          'ops': ["scale_in 300 300"],
-                          },
-        'crisp': {'type': 'responsive-image',
-                  'srcset': [('1x', ["scale_in 800 600 True"]),
-                             ('2x', ["scale_in 1600 1200 True"]),
-                             ('4x', ["scale_in 3200 2400 True"]),
-                             ],
-                  'default': '1x',
-                  },
-        'crisp2': {'type': 'responsive-image',
-                   'srcset': [('1x', ["scale_in 800 600 True"]),
-                              ('2x', ["scale_in 1600 1200 True"]),
-                              ('4x', ["scale_in 3200 2400 True"]),
-                              ],
-                   'default': ["scale_in 400 300 True"],
-                   },
-        'large-photo': {'type': 'responsive-image',
-                        'sizes': '(min-width: 1200px) 800px, (min-width: 992px) 650px, (min-width: 768px) 718px, 100vw',
-                        'srcset': [('600w', ["scale_in 600 450 True"]),
-                                   ('800w', ["scale_in 800 600 True"]),
-                                   ('1600w', ["scale_in 1600 1200 True"]),
-                                   ],
-                        'default': '800w',
-                        },
-        'pict': {'type': 'picture',
-                 'sources': [{'name': 'default',
-                              'media': '(min-width: 640px)',
-                              'srcset': [('640w', ["scale_in 640 480 True"]),
-                                         ('1024w', ["scale_in 1024 683 True"]),
-                                         ('1600w', ["scale_in 1600 1200 True"]),
-                                         ],
-                              'sizes': '100vw',
-                              },
-                             {'name': 'source-1',
-                              'srcset': [('1x', ["crop 100 100 200 200"]),
-                                         ('2x', ["crop 100 100 300 300"]),
-                                         ]
-                              }
-                             ],
-                 'default': ('default', '640w'),
-                 },
-        'pict2': {'type': 'picture',
-                  'sources': [{'name': 'default',
-                               'media': '(min-width: 640px)',
-                               'srcset': [('640w', ["scale_in 640 480 True"]),
-                                          ('1024w', ["scale_in 1024 683 True"]),
-                                          ('1600w', ["scale_in 1600 1200 True"]),
-                                          ],
-                               'sizes': '100vw',
-                               },
-                              {'name': 'source-2',
-                               'srcset': [('1x', ["crop 100 100 200 200"]),
-                                          ('2x', ["crop 100 100 300 300"]),
+        'article-image': {
+            'type': 'image', 'ops': ["scale_in 300 300"],
+        },
+        'crisp': {
+            'type': 'responsive-image',
+             'srcset': [('1x', ["scale_in 800 600 True"]),
+                        ('2x', ["scale_in 1600 1200 True"]),
+                        ('4x', ["scale_in 3200 2400 True"])],
+              'default': '1x',
+        },
+        'crisp2': {
+            'type': 'responsive-image',
+            'srcset': [('1x', ["scale_in 800 600 True"]),
+                       ('2x', ["scale_in 1600 1200 True"]),
+                       ('4x', ["scale_in 3200 2400 True"])],
+            'default': ["scale_in 400 300 True"],
+        },
+        'large-photo': {
+            'type': 'responsive-image',
+            'sizes': (
+                '(min-width: 1200px) 800px, (min-width: 992px) 650px, '
+                '(min-width: 768px) 718px, 100vw'
+            ),
+            'srcset': [('600w', ["scale_in 600 450 True"]),
+                       ('800w', ["scale_in 800 600 True"]),
+                       ('1600w', ["scale_in 1600 1200 True"])],
+            'default': '800w',
+        },
+        'pict': {
+            'type': 'picture',
+            'sources': [
+                {
+                    'name': 'default',
+                    'media': '(min-width: 640px)',
+                    'srcset': [('640w', ["scale_in 640 480 True"]),
+                               ('1024w', ["scale_in 1024 683 True"]),
+                               ('1600w', ["scale_in 1600 1200 True"])],
+                    'sizes': '100vw',
+                }, {
+                    'name': 'source-1',
+                    'srcset': [('1x', ["crop 100 100 200 200"]),
+                               ('2x', ["crop 100 100 300 300"])]
+                }
+            ],
+            'default': ('default', '640w'),
+        },
+        'pict2': {
+            'type': 'picture',
+            'sources': [
+                {
+                    'name': 'default',
+                    'media': '(min-width: 640px)',
+                    'srcset': [('640w', ["scale_in 640 480 True"]),
+                               ('1024w', ["scale_in 1024 683 True"]),
+                               ('1600w', ["scale_in 1600 1200 True"])],
+                    'sizes': '100vw'
+                }, {
+                    'name': 'source-2',
+                    'srcset': [('1x', ["crop 100 100 200 200"]),
+                               ('2x', ["crop 100 100 300 300"]),
                                           ]
-                               }
-                              ],
-                  'default': ('source-2', ["scale_in 800 600 True"]),
-                  },
-        }
+                }
+            ],
+            'default': ('source-2', ["scale_in 800 600 True"]),
+        },
+    }
 
     def test_undefined(self):
-        settings = get_settings(IMAGE_PROCESS = self.valid_transforms)
+        settings = get_settings(IMAGE_PROCESS=self.valid_transforms)
         html = '<img class="image-process-undefined" src="/tmp/test.jpg" />'
-        c = Instance(html, settings)
-        del images[:]
         with self.assertRaises(RuntimeError):
-            harvest_images(c)
+            harvest_images_in_fragment(html, settings)
 
 
-    def test_image_generation(self):
-        settings = get_settings(IMAGE_PROCESS=self.valid_transforms, IMAGE_PROCESS_DIR='derivs')
+    @mock.patch('image_process.process_image')
+    def test_image_generation(self, process_image):
+        settings = get_settings(IMAGE_PROCESS=self.valid_transforms,
+                                IMAGE_PROCESS_DIR='derivs')
+
         test_data = [
             ('<img class="image-process-thumb" src="/tmp/test.jpg" />',
-             '<img class="image-process-thumb" src="/tmp/derivs/thumb/test.jpg"/>',
-             ('tmp/test.jpg', 'thumb/test.jpg', ["crop 0 0 50% 50%", "scale_out 150 150", "crop 0 0 150 150"])
-             ),
-            ('<img class="image-process-article-image" src="/tmp/test.jpg" />',
-             '<img class="image-process-article-image" src="/tmp/derivs/article-image/test.jpg"/>',
-             ('tmp/test.jpg', 'article-image/test.jpg', ["scale_in 300 300"])
+             '<img class="image-process-thumb" '
+             'src="/tmp/derivs/thumb/test.jpg"/>',
+             (
+                 'tmp/test.jpg', 'thumb/test.jpg',
+                 ["crop 0 0 50% 50%", "scale_out 150 150", "crop 0 0 150 150"]
              )
-           ]
+            ),
+            ('<img class="image-process-article-image" src="/tmp/test.jpg" />',
+             '<img class="image-process-article-image" '
+             'src="/tmp/derivs/article-image/test.jpg"/>',
+             ('tmp/test.jpg', 'article-image/test.jpg', ["scale_in 300 300"])
+            )
+        ]
 
         for data in test_data:
             expected_source = os.path.join(settings['PATH'], data[2][0])
-            output_path, _ = os.path.split(expected_source)
-            base_path = os.path.join(output_path, settings['IMAGE_PROCESS_DIR'])
-            expected_destination = os.path.join(base_path, data[2][1])
+            expected_destination = os.path.join(
+                settings['OUTPUT_PATH'], 'tmp', settings['IMAGE_PROCESS_DIR'],
+                data[2][1]
+            )
+            html = harvest_images_in_fragment(data[0], settings)
 
-            c = Instance(data[0], settings)
+            expected_image = (expected_source, expected_destination,
+                              data[2][2])
 
-            del images[:]
-            harvest_images(c)
-
-            expected_images = [(expected_source, expected_destination, data[2][2])]
-
-            self.assertEqual(c._content, data[1])
-            self.assertEqual(images, expected_images)
+            expected_calls = [mock.call(expected_image, settings)]
+            self.assertEqual(html, data[1])
+            self.assertEqual(expected_calls, process_image.call_args_list)
+            process_image.reset_mock()
 
 
-    def test_responsive_image_generation(self):
-        settings = get_settings(IMAGE_PROCESS=self.valid_transforms, IMAGE_PROCESS_DIR='derivs')
+    @mock.patch('image_process.process_image')
+    def test_responsive_image_generation(self, process_image):
+        settings = get_settings(IMAGE_PROCESS=self.valid_transforms,
+                                IMAGE_PROCESS_DIR='derivs')
         test_data = [
             ('<img class="image-process-crisp" src="/tmp/test.jpg" />',
-             '<img class="image-process-crisp" src="/tmp/derivs/crisp/1x/test.jpg" srcset="/tmp/derivs/crisp/1x/test.jpg 1x, /tmp/derivs/crisp/2x/test.jpg 2x, /tmp/derivs/crisp/4x/test.jpg 4x"/>',
-             [('tmp/test.jpg', 'crisp/1x/test.jpg', ["scale_in 800 600 True"]),
-              ('tmp/test.jpg', 'crisp/2x/test.jpg', ["scale_in 1600 1200 True"]),
-              ('tmp/test.jpg', 'crisp/4x/test.jpg', ["scale_in 3200 2400 True"]),
+             '<img class="image-process-crisp" '
+             'src="/tmp/derivs/crisp/1x/test.jpg" '
+             'srcset="/tmp/derivs/crisp/1x/test.jpg 1x, '
+             '/tmp/derivs/crisp/2x/test.jpg 2x, '
+             '/tmp/derivs/crisp/4x/test.jpg 4x"/>',
+
+             [('tmp/test.jpg', 'crisp/1x/test.jpg',
+                  ["scale_in 800 600 True"]),
+              ('tmp/test.jpg', 'crisp/2x/test.jpg',
+                  ["scale_in 1600 1200 True"]),
+              ('tmp/test.jpg', 'crisp/4x/test.jpg',
+                  ["scale_in 3200 2400 True"]),
               ]),
 
             ('<img class="image-process-crisp2" src="/tmp/test.jpg" />',
-             '<img class="image-process-crisp2" src="/tmp/derivs/crisp2/default/test.jpg" srcset="/tmp/derivs/crisp2/1x/test.jpg 1x, /tmp/derivs/crisp2/2x/test.jpg 2x, /tmp/derivs/crisp2/4x/test.jpg 4x"/>',
-             [('tmp/test.jpg', 'crisp2/1x/test.jpg', ["scale_in 800 600 True"]),
-              ('tmp/test.jpg', 'crisp2/2x/test.jpg', ["scale_in 1600 1200 True"]),
-              ('tmp/test.jpg', 'crisp2/4x/test.jpg', ["scale_in 3200 2400 True"]),
-              ('tmp/test.jpg', 'crisp2/default/test.jpg', ["scale_in 400 300 True"])
-              ]),
+             '<img class="image-process-crisp2" '
+             'src="/tmp/derivs/crisp2/default/test.jpg" '
+             'srcset="/tmp/derivs/crisp2/1x/test.jpg 1x, '
+             '/tmp/derivs/crisp2/2x/test.jpg 2x, '
+             '/tmp/derivs/crisp2/4x/test.jpg 4x"/>',
+
+             # default must be first, because the process execute it first
+             [('tmp/test.jpg', 'crisp2/default/test.jpg',
+                  ["scale_in 400 300 True"]),
+              ('tmp/test.jpg', 'crisp2/1x/test.jpg',
+                  ["scale_in 800 600 True"]),
+              ('tmp/test.jpg', 'crisp2/2x/test.jpg',
+                  ["scale_in 1600 1200 True"]),
+              ('tmp/test.jpg', 'crisp2/4x/test.jpg',
+                  ["scale_in 3200 2400 True"])
+             ]),
 
             ('<img class="image-process-large-photo" src="/tmp/test.jpg" />',
-             '<img class="image-process-large-photo" sizes="(min-width: 1200px) 800px, (min-width: 992px) 650px, (min-width: 768px) 718px, 100vw" src="/tmp/derivs/large-photo/800w/test.jpg" srcset="/tmp/derivs/large-photo/600w/test.jpg 600w, /tmp/derivs/large-photo/800w/test.jpg 800w, /tmp/derivs/large-photo/1600w/test.jpg 1600w"/>',
-             [('tmp/test.jpg', 'large-photo/600w/test.jpg', ["scale_in 600 450 True"]),
-              ('tmp/test.jpg', 'large-photo/800w/test.jpg', ["scale_in 800 600 True"]),
-              ('tmp/test.jpg', 'large-photo/1600w/test.jpg', ["scale_in 1600 1200 True"]),
+             '<img class="image-process-large-photo" sizes="(min-width: 1200px) '
+             '800px, (min-width: 992px) 650px, (min-width: 768px) 718px, '
+             '100vw" src="/tmp/derivs/large-photo/800w/test.jpg" '
+             'srcset="/tmp/derivs/large-photo/600w/test.jpg 600w, '
+             '/tmp/derivs/large-photo/800w/test.jpg 800w, '
+             '/tmp/derivs/large-photo/1600w/test.jpg 1600w"/>',
+             [('tmp/test.jpg', 'large-photo/600w/test.jpg',
+                  ["scale_in 600 450 True"]),
+              ('tmp/test.jpg', 'large-photo/800w/test.jpg',
+                  ["scale_in 800 600 True"]),
+              ('tmp/test.jpg', 'large-photo/1600w/test.jpg',
+                  ["scale_in 1600 1200 True"]),
               ]),
-           ]
+        ]
 
         for data in test_data:
-            c = Instance(data[0], settings)
+            html = harvest_images_in_fragment(data[0], settings)
 
-            del images[:]
-            harvest_images(c)
+            expected_images = []
+            expected_calls = []
 
-            expected_images = list()
             for t in data[2]:
                 expected_source = os.path.join(settings['PATH'], t[0])
-                output_path, _ = os.path.split(expected_source)
-                base_path = os.path.join(output_path, settings['IMAGE_PROCESS_DIR'])
-                expected_destination = os.path.join(base_path, t[1])
-                expected_images.append((expected_source, expected_destination, t[2]))
+                expected_destination = os.path.join(
+                    settings['OUTPUT_PATH'], 'tmp',
+                    settings['IMAGE_PROCESS_DIR'], t[1]
+                )
+
+                expected_image = (expected_source, expected_destination, t[2])
+                expected_images.append(expected_image)
+                expected_calls.append(mock.call(expected_image, settings))
+
 
             self.maxDiff = None
-            self.assertEqual(c._content, data[1])
-            for i in images:
-                self.assertIn(i, expected_images)
-            for i in expected_images:
-                self.assertIn(i, images)
+            self.assertEqual(html, data[1])
+            self.assertEqual(process_image.call_args_list, expected_calls)
+
+            process_image.reset_mock()
 
 
-    def test_picture_generation(self):
-        settings = get_settings(IMAGE_PROCESS=self.valid_transforms, IMAGE_PROCESS_DIR='derivs')
+    @mock.patch('image_process.process_image')
+    def test_picture_generation(self, process_image):
+        settings = get_settings(IMAGE_PROCESS=self.valid_transforms,
+                                IMAGE_PROCESS_DIR='derivs')
         test_data = [
-            ('<picture><source class="source-1" src="/images/pelican-closeup.jpg"></source><img class="image-process-pict" src="/images/pelican.jpg"/></picture>',
-             '<picture><source media="(min-width: 640px)" sizes="100vw" srcset="/images/derivs/pict/default/640w/pelican.jpg 640w, /images/derivs/pict/default/1024w/pelican.jpg 1024w, /images/derivs/pict/default/1600w/pelican.jpg 1600w"></source><source srcset="/images/derivs/pict/source-1/1x/pelican-closeup.jpg 1x, /images/derivs/pict/source-1/2x/pelican-closeup.jpg 2x"></source><img class="image-process-pict" src="/images/derivs/pict/default/640w/pelican.jpg"/></picture>',
-             [('images/pelican.jpg', 'pict/default/640w/pelican.jpg', ["scale_in 640 480 True"]),
-              ('images/pelican.jpg', 'pict/default/1024w/pelican.jpg', ["scale_in 1024 683 True"]),
-              ('images/pelican.jpg', 'pict/default/1600w/pelican.jpg', ["scale_in 1600 1200 True"]),
-              ('images/pelican-closeup.jpg', 'pict/source-1/1x/pelican-closeup.jpg', ["crop 100 100 200 200"]),
-              ('images/pelican-closeup.jpg', 'pict/source-1/2x/pelican-closeup.jpg', ["crop 100 100 300 300"])
+            ('<picture><source class="source-1" '
+             'src="/images/pelican-closeup.jpg"></source><img '
+             'class="image-process-pict" src="/images/pelican.jpg"/>'
+             '</picture>',
+
+             '<picture><source media="(min-width: 640px)" sizes="100vw" '
+             'srcset="/images/derivs/pict/default/640w/pelican.jpg 640w, '
+             '/images/derivs/pict/default/1024w/pelican.jpg 1024w, '
+             '/images/derivs/pict/default/1600w/pelican.jpg 1600w">'
+             '</source><source srcset="/images/derivs/pict/source-1/1x/'
+             'pelican-closeup.jpg 1x, /images/derivs/pict/source-1/2x/'
+             'pelican-closeup.jpg 2x"></source><img class="image-process-pict"'
+             ' src="/images/derivs/pict/default/640w/pelican.jpg"/></picture>',
+
+             [('images/pelican.jpg', 'pict/default/640w/pelican.jpg',
+                 ["scale_in 640 480 True"]),
+              ('images/pelican.jpg', 'pict/default/1024w/pelican.jpg',
+                 ["scale_in 1024 683 True"]),
+              ('images/pelican.jpg', 'pict/default/1600w/pelican.jpg',
+                 ["scale_in 1600 1200 True"]),
+              ('images/pelican-closeup.jpg',
+                  'pict/source-1/1x/pelican-closeup.jpg',
+                  ["crop 100 100 200 200"]),
+              ('images/pelican-closeup.jpg',
+                  'pict/source-1/2x/pelican-closeup.jpg',
+                  ["crop 100 100 300 300"])
               ]),
 
-            ('<div class="figure"><img alt="Pelican" class="image-process-pict2" src="/images/pelican.jpg" /> <p class="caption">A nice pelican</p> <div class="legend"> <img alt="Other view of pelican" class="image-process source-2" src="/images/pelican-closeup.jpg" /> </div> </div>',
-             '<div class="figure"><picture><source media="(min-width: 640px)" sizes="100vw" srcset="/images/derivs/pict2/default/640w/pelican.jpg 640w, /images/derivs/pict2/default/1024w/pelican.jpg 1024w, /images/derivs/pict2/default/1600w/pelican.jpg 1600w"></source><source srcset="/images/derivs/pict2/source-2/1x/pelican-closeup.jpg 1x, /images/derivs/pict2/source-2/2x/pelican-closeup.jpg 2x"></source><img alt="Pelican" class="image-process-pict2" src="/images/derivs/pict2/source-2/default/pelican-closeup.jpg"/></picture> <p class="caption">A nice pelican</p> <div class="legend">  </div> </div>',
-             [('images/pelican.jpg', 'pict2/default/640w/pelican.jpg', ["scale_in 640 480 True"]),
-              ('images/pelican.jpg', 'pict2/default/1024w/pelican.jpg', ["scale_in 1024 683 True"]),
-              ('images/pelican.jpg', 'pict2/default/1600w/pelican.jpg', ["scale_in 1600 1200 True"]),
-              ('images/pelican-closeup.jpg', 'pict2/source-2/1x/pelican-closeup.jpg', ["crop 100 100 200 200"]),
-              ('images/pelican-closeup.jpg', 'pict2/source-2/2x/pelican-closeup.jpg', ["crop 100 100 300 300"]),
-              ('images/pelican-closeup.jpg', 'pict2/source-2/default/pelican-closeup.jpg', ["scale_in 800 600 True"])
+            ('<div class="figure"><img alt="Pelican" class="image-process'
+            '-pict2" src="/images/pelican.jpg" /> <p class="caption">'
+            'A nice pelican</p> <div class="legend"> <img alt="Other view of '
+            'pelican" class="image-process source-2" src="/images/'
+            'pelican-closeup.jpg" /> </div> </div>',
+
+             '<div class="figure"><picture><source media="(min-width: 640px)" '
+             'sizes="100vw" srcset="/images/derivs/pict2/default/640w/pelican'
+             '.jpg 640w, /images/derivs/pict2/default/1024w/pelican.jpg 1024w, '
+             '/images/derivs/pict2/default/1600w/pelican.jpg 1600w"></source>'
+             '<source srcset="/images/derivs/pict2/source-2/1x/pelican-closeup'
+             '.jpg 1x, /images/derivs/pict2/source-2/2x/pelican-closeup.jpg '
+             '2x"></source><img alt="Pelican" class="image-process-pict2" '
+             'src="/images/derivs/pict2/source-2/default/pelican-closeup.jpg"/>'
+             '</picture> <p class="caption">A nice pelican</p> <div '
+             'class="legend">  </div> </div>',
+
+             [('images/pelican.jpg', 'pict2/default/640w/pelican.jpg',
+                 ["scale_in 640 480 True"]),
+              ('images/pelican.jpg', 'pict2/default/1024w/pelican.jpg',
+                 ["scale_in 1024 683 True"]),
+              ('images/pelican.jpg', 'pict2/default/1600w/pelican.jpg',
+                 ["scale_in 1600 1200 True"]),
+              ('images/pelican-closeup.jpg',
+                 'pict2/source-2/1x/pelican-closeup.jpg',
+                 ["crop 100 100 200 200"]),
+              ('images/pelican-closeup.jpg',
+                 'pict2/source-2/2x/pelican-closeup.jpg',
+                 ["crop 100 100 300 300"]),
+              ('images/pelican-closeup.jpg',
+                 'pict2/source-2/default/pelican-closeup.jpg',
+                 ["scale_in 800 600 True"])
               ]),
            ]
 
         for data in test_data:
-            c = Instance(data[0], settings)
+            html = harvest_images_in_fragment(data[0], settings)
 
-            del images[:]
-            harvest_images(c)
-
-            expected_images = list()
+            expected_images = []
+            expected_calls = []
             for t in data[2]:
                 expected_source = os.path.join(settings['PATH'], t[0])
-                output_path, _ = os.path.split(expected_source)
-                base_path = os.path.join(output_path, settings['IMAGE_PROCESS_DIR'])
-                expected_destination = os.path.join(base_path, t[1])
-                expected_images.append((expected_source, expected_destination, t[2]))
+                expected_destination = os.path.join(
+                    settings['OUTPUT_PATH'], 'tmp',
+                    settings['IMAGE_PROCESS_DIR'], t[1]
+                )
+
+                expected_image = (expected_source, expected_destination, t[2])
+                expected_images.append(expected_image)
+                expected_calls.append(mock.call(expected_image, settings))
 
             self.maxDiff = None
-            self.assertEqual(c._content, data[1])
-            for i in images:
-                self.assertIn(i, expected_images)
-            for i in expected_images:
-                self.assertIn(i, images)
+            self.assertEqual(html, data[1])
+            #for i in images:
+            #    self.assertIn(i, expected_images)
+            #for i in expected_images:
+            #    self.assertIn(i, images)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Hello,

I am a huge fan of pelican and your library was really helpful for manipulating images.
But, there is a major issue with [internal linking](http://docs.getpelican.com/en/3.6.0/content.html#linking-to-static-files) and more specifically with the `{filename}` syntax.

So I moved the signal hook `from content_init` to `content_written`
I refactored the code accordingly, I simplified the harvest_images_in_fragment code (no more nested if and for)
I also moved the generated content (the new images) to the output folder. IMHO generated content must not be saved at the same places as the sources. If the generation change it will be complicated to remember which are the source, which are the generated files and which one I can safely delete.

I also fixed the tests, and rewrite those who needed it. I added a support for [travis](https://travis-ci.org/) which test the package on python 2.7, 3.3 and 3.4. 

Finally, I make all of the package pep8 compliant, which is also tested by travis. 

Let me know if there is improvement points or if something need to be changed.