### PR TITLE
Introduce IMAGE_PROCESS_PARSER config option

### DIFF
--- a/Readme.rst
+++ b/Readme.rst
@@ -438,6 +438,20 @@ file.
    IMAGE_PROCESS_FORCE = True
 
 
+Selecting a HTML parser
+~~~~~~~~~~~~~~~~~~~~~~~
+
+You may select the HTML parser which is used. The default is the builtin
+``html.parser`` but you may also select ``html5lib`` or ``lxml`` by setting
+``IMAGE_PROCESS_PARSER`` in your pelican configuration file , e.g.:
+
+.. code-block:: python
+
+   IMAGE_PROCESS_PARSER = "html5lib"
+
+For details, refer to the `BeautifulSoup documentation on parsers
+<https://www.crummy.com/software/BeautifulSoup/bs4/doc/#installing-a-parser>`_.
+
 Credits
 -------
 

--- a/image_process.py
+++ b/image_process.py
@@ -184,7 +184,8 @@ def harvest_images(path, context):
 
 
 def harvest_images_in_fragment(fragment, settings):
-    soup = BeautifulSoup(fragment, 'html.parser')
+    parser = settings.get("IMAGE_PROCESS_PARSER", "html.parser")
+    soup = BeautifulSoup(fragment, parser)
 
     for img in soup.find_all('img', class_=IMAGE_PROCESS_REGEX):
         for c in img['class']:


### PR DESCRIPTION
IMAGE_PROCESS_PARSER allows the user to select the html parser
used by BeautifulSoup, html.parser is still the default.