### PR TITLE
Optional directory creation per transformation name

### DIFF
--- a/Readme.rst
+++ b/Readme.rst
@@ -413,6 +413,24 @@ the same location as the original image.
 For example if the original image is located in
 the ``content/images`` folder. The computed images will be stored
 in the ``output/images/derivative/<TRANSFORMATION_NAME>``.
+
+To avoid the creation of these directories ``<TRANSFORMATION_NAME>``
+and consequently the replication of images in the output, we can set
+the ``create-dir`` flag to ``False`` inside each transformation configuration:
+
+.. code-block:: python
+
+  IMAGE_PROCESS = {
+      'large-photo': {
+          'type': '...',
+          'sizes': '...',
+          'srcset': [('...', '...')],
+          'default': '...',
+          'create-dir': False
+       }
+  }
+
+
 All the transformations are done in the output directory in order
 to avoid confusion with the source files or if we test multiple
 transformations.

--- a/image_process.py
+++ b/image_process.py
@@ -232,14 +232,22 @@ def harvest_images_in_fragment(fragment, settings):
 
 
 def compute_paths(img, settings, derivative):
+    if settings['IMAGE_PROCESS'][derivative].get('create-dir', True):
+        d = derivative
+    else:
+        d = ''
+
     process_dir = settings['IMAGE_PROCESS_DIR']
     url_path, filename = os.path.split(img['src'])
-    base_url = os.path.join(url_path, process_dir, derivative)
+    base_url = os.path.join(url_path, process_dir, d)
 
     for f in settings['filenames']:
         if os.path.basename(img['src']) in f:
             source = settings['filenames'][f].source_path
-            base_path = os.path.join(settings['OUTPUT_PATH'], os.path.dirname(settings['filenames'][f].save_as), process_dir, derivative)
+            base_path = os.path.join(settings['OUTPUT_PATH'],
+                                     os.path.dirname(settings['filenames'][f].save_as),
+                                     process_dir,
+                                     d)
             break
     else:
         source = os.path.join(settings['PATH'], img['src'][1:])

--- a/image_process.py
+++ b/image_process.py
@@ -13,6 +13,7 @@ import functools
 import os.path
 import re
 import six
+import urllib
 
 from PIL import Image, ImageFilter
 from bs4 import BeautifulSoup
@@ -242,10 +243,11 @@ def compute_paths(img, settings, derivative):
     base_url = os.path.join(url_path, process_dir, d)
 
     for f in settings['filenames']:
-        if os.path.basename(img['src']) in f:
+        if urllib.parse.urlparse(img['src']).path[1:] in settings['filenames'][f].get_url_setting('save_as'):
+
             source = settings['filenames'][f].source_path
             base_path = os.path.join(settings['OUTPUT_PATH'],
-                                     os.path.dirname(settings['filenames'][f].save_as),
+                                     os.path.dirname(settings['filenames'][f].get_url_setting('save_as')),
                                      process_dir,
                                      d)
             break


### PR DESCRIPTION
I'm using this plugin on a website and I found it would be useful if the creation of a directory for each transformation name would be optional.
This allows the reuse (avoiding duplication) of generated images if we use the same `srcset` on different transformations.
The default behavior is the same that it was before.